### PR TITLE
Adding more details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,27 @@
 # TCR Tool
 
 ## Install
-Instructions for now:
+
+Current instructions for building: 
 
 1. Install Rust
-2. `cargo build`
+2. Clone the Repo `git clone https://github.com/jazzdan/tcr`
+3. Cd into the repo and run `cargo build`
+4. The TCR binary should be installed to `/target/debug/tcr`
+
+## Usage
+
+The `tcr` binary should be aliased or added to your $PATH variable to make it accessible from different directories. 
+
+To use the tool, run `tcr` on a local Git repo of your choice. The tool expects a `.tcr` file to be present in the directory where it's run. A `.tcr` file has the following structure:
+
+```
+{
+    "build_cmd": "cargo build",
+    "test_cmd": "cargo test",
+    "revert_cmd": "git reset HEAD --hard",
+    "commit_cmd": "git commit -am working"
+}
+```
+
+The keys in the `.tcr` file must be literals per the example, but the command values should be modified to meet your needs. For example, the above is for a Rust project -- hence the `cargo` commands.

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,10 +74,10 @@ fn watch_and_run<P: AsRef<Path>>(
         cmd: cmd_from_string(config.commit_cmd).unwrap(),
     };
     let tester = &mut CmdRunner {
-        cmd: cmd_from_string(config.revert_cmd).unwrap(),
+        cmd: cmd_from_string(config.test_cmd).unwrap(),
     };
     let reverter = &mut CmdRunner {
-        cmd: cmd_from_string(config.test_cmd).unwrap(),
+        cmd: cmd_from_string(config.revert_cmd).unwrap(),
     };
 
     let root = std::env::current_dir().unwrap();


### PR DESCRIPTION
Fixing the `revert` and `test` switches to. that commits don't get reverted.
Also adding some preliminary details fo the README.